### PR TITLE
Add endpoint_type in list identity.Endpoint

### DIFF
--- a/src/spaceone/identity/conf/global_conf.py
+++ b/src/spaceone/identity/conf/global_conf.py
@@ -63,3 +63,47 @@ ENDPOINTS = [
     #     'endpoint': 'grpc://<endpoint>>:<port>/v1'
     # },
 ]
+
+# Internal Endpoint
+INTERNAL_ENDPOINTS = [
+    {
+        'service': 'identity',
+        'name': 'Identity Service',
+        'endpoint': 'grpc://identity.spaceone.svc.cluster.local:50051/v1'
+    },
+    {
+        'service': 'secret',
+        'name': 'Secret Service',
+        'endpoint': 'grpc://secret.spaceone.svc.cluster.local:50051/v1'
+    },
+    {
+        'service': 'repository',
+        'name': 'Repository Service',
+        'endpoint': 'grpc://repository.spaceone.svc.cluster.local:50051/v1'
+    },
+    {
+        'service': 'plugin',
+        'name': 'Plugin Service',
+        'endpoint': 'grpc://plugin.spaceone.svc.cluster.local:50051/v1'
+    },
+    {
+        'service': 'config',
+        'name': 'Config Service',
+        'endpoint': 'grpc://config.spaceone.svc.cluster.local:50051/v1'
+    },
+    {
+        'service': 'inventory',
+        'name': 'Inventory Service',
+        'endpoint': 'grpc://inventory.spaceone.svc.cluster.local:50051/v1'
+    },
+    {
+        'service': 'monitoring',
+        'name': 'Monitoring Service',
+        'endpoint': 'grpc://monitoring.spaceone.svc.cluster.local:50051/v1'
+    },
+    {
+        'service': 'statistics',
+        'name': 'Statistics Service',
+        'endpoint': 'grpc://statistics.spaceone.svc.cluster.local:50051/v1'
+    }
+]

--- a/src/spaceone/identity/manager/endpoint_manager.py
+++ b/src/spaceone/identity/manager/endpoint_manager.py
@@ -5,9 +5,14 @@ from spaceone.core.manager import BaseManager
 
 _LOGGER = logging.getLogger(__name__)
 
+ENDPOINT_MAP = {
+        'public': 'ENDPOINTS',
+        'internal': 'INTERNAL_ENDPOINTS'
+        }
 
 class EndpointManager(BaseManager):
 
-    def list_endpoints(self, query={}):
-        endpoints = config.get_global('ENDPOINTS', [])
+    def list_endpoints(self, query={}, endpoint_type='public'):
+        endpoint_map = ENDPOINT_MAP.get(endpoint_type, 'ENDPOINTS')
+        endpoints = config.get_global(endpoint_map, [])
         return endpoints, len(endpoints)

--- a/src/spaceone/identity/service/endpoint_service.py
+++ b/src/spaceone/identity/service/endpoint_service.py
@@ -20,11 +20,12 @@ class EndpointService(BaseService):
         Args:
             params (dict): {
                     'query': 'dict (spaceone.api.core.v1.Query)',
-                    'service': 'str'
+                    'service': 'str',
+                    'endpoint_type': 'str'
                 }
 
         Returns:
             results (list): list of endpoint_vo
             total_count (int)
         """
-        return self.endpoint_mgr.list_endpoints(params.get('query', {}))
+        return self.endpoint_mgr.list_endpoints(params.get('query', {}), params.get('endpoint_type', 'public'))


### PR DESCRIPTION
endpoint_type : public | internal

root@identity-57c8f57758-n7hvp:~# spacectl list identity.Endpoint -p endpoint_type=internal
 service    | name               | endpoint
------------+--------------------+-------------------------------------------------------
 identity   | Identity Service   | grpc://identity.spaceone.svc.cluster.local:50051/v1
 secret     | Secret Service     | grpc://secret.spaceone.svc.cluster.local:50051/v1
 repository | Repository Service | grpc://repository.spaceone.svc.cluster.local:50051/v1
 plugin     | Plugin Service     | grpc://plugin.spaceone.svc.cluster.local:50051/v1
 config     | Config Service     | grpc://config.spaceone.svc.cluster.local:50051/v1
 inventory  | Inventory Service  | grpc://inventory.spaceone.svc.cluster.local:50051/v1
 monitoring | Monitoring Service | grpc://monitoring.spaceone.svc.cluster.local:50051/v1
 statistics | Statistics Service | grpc://statistics.spaceone.svc.cluster.local:50051/v1

Signed-off-by: Choonho Son <choonhoson@megazone.com>